### PR TITLE
Allow empty bindings in override bindings

### DIFF
--- a/src/menu/whichKeyMenuItem.ts
+++ b/src/menu/whichKeyMenuItem.ts
@@ -19,10 +19,10 @@ export default class WhichKeyMenuItem implements MenuItem {
         this.command = item.command;
         this.commands = item.commands;
         this.args = item.args;
-        if (this.type === ActionType.Bindings && item.bindings) {
-            this.items = WhichKeyMenuItem.createItems(item.bindings);
-        } else if (this.type === ActionType.Transient && item.bindings) {
-            this.items = WhichKeyMenuItem.createItems(item.bindings);
+        if (this.type === ActionType.Bindings) {
+            this.items = WhichKeyMenuItem.createItems(item.bindings ?? []);
+        } else if (this.type === ActionType.Transient) {
+            this.items = WhichKeyMenuItem.createItems(item.bindings ?? []);
         }
     }
 


### PR DESCRIPTION
This allows override bindings to not declare a bindings array. This can be useful if the bindings menu will be populated with other overrides. For instance, the sample config will now work:

```json
{
  "whichkey.bindingOverrides": [
    {
      "keys": "g.H",
      "name": "Hunks",
      "type": "bindings"
    },
    {
      "keys": "g.H.s",
      "name": "Stage hunk",
      "type": "command",
      "command": "git.stageSelectedRanges"
    }
  ]
}
```


Previously, the former config would fail to populate the "Hunks" menu due to the missing bindings entry defaulting to null instead of an empty array. This would cause the overrideBindings function to behave as if the "Hunks" menu didn't exist, and fail to append the item.