### PR TITLE
Sort which key menu items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add a configuration (`whichkey.sortOrder`) to sort menu items
 
 ## [0.7.4] - 2020-07-27
 ### Changed

--- a/README.md
+++ b/README.md
@@ -254,6 +254,9 @@ Once you've done that, you can use `C-x` in the `key` value of the which-key con
 ### Display menu with a delay
 You can set `whichkey.delay` in `settings.json` to value in millisecond to delay the display of the menu.
 
+### Display menu items alphabetically
+You can set `whichkey.sortOrder` in `settings.json` to `alphabetically` to always display the menu items alphabetically.
+
 ## Release Notes
 
 See [CHANGELOG.md](CHANGELOG.md)

--- a/package.json
+++ b/package.json
@@ -65,6 +65,16 @@
 						"markdownDescription": "Delay (in milliseconds) for which-key menu to display.",
 						"default": 0
 					},
+					"whichkey.sortOrder": {
+						"type": "string",
+						"default": "none",
+						"enum": ["none", "alphabetically"],
+						"enumDescriptions": [
+							"Menu items are not sorted.",
+							"Menu items are sorted in alphabetical order."
+						],
+						"markdownDescription": "Controls the sorting order of the which-key menu items."
+					},
 					"whichkey.bindings": {
 						"type": "array",
 						"markdownDescription": "The bindings of the which key menu",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,7 @@ export const publisherId = 'VSpaceCode';
 export const contributePrefix = 'whichkey';
 export enum ConfigKey {
 	Delay = "delay",
+	SortOrder = "sortOrder",
 	Bindings = "bindings",
 	Overrides = "bindingOverrides",
 }
@@ -10,6 +11,11 @@ export enum CommandKey {
 	Show = 'show',
 	Register = 'register',
 	Trigger = 'triggerKey',
+}
+
+export enum SortOrder {
+	None = 'none',
+	Alphabetically = 'alphabetically',
 }
 
 export enum ContextKey {

--- a/src/menu/menuItem.ts
+++ b/src/menu/menuItem.ts
@@ -1,5 +1,6 @@
 import { QuickPickItem } from 'vscode';
 import { ActionType, BindingItem, OverrideBindingItem } from "../bindingItem";
+import { SortOrder } from '../constants';
 
 export default class MenuItem implements QuickPickItem {
     name: string;
@@ -27,9 +28,9 @@ export default class MenuItem implements QuickPickItem {
         this.commands = item.commands;
         this.args = item.args;
         if (this.type === ActionType.Bindings && item.bindings) {
-            this.items = MenuItem.createItems(item.bindings);
+            this.items = MenuItem.createMenuItems(item.bindings);
         } else if (this.type === ActionType.Transient && item.bindings) {
-            this.items = MenuItem.createItems(item.bindings);
+            this.items = MenuItem.createMenuItems(item.bindings);
         }
     }
 
@@ -42,11 +43,11 @@ export default class MenuItem implements QuickPickItem {
         return `\t${this.name}`;
     }
 
-    static createItems(items: BindingItem[]) {
-        return items.map(i => new MenuItem(i));
+    static createMenuItems(bindingItems: BindingItem[]) {
+        return bindingItems.map(i => new MenuItem(i));
     }
 
-    static overrideItems(
+    static overrideMenuItems(
         items?: MenuItem[],
         overrides?: OverrideBindingItem[]) {
         overrides?.forEach(o => {
@@ -98,6 +99,17 @@ export default class MenuItem implements QuickPickItem {
                 console.error(e);
             }
         });
+    }
+
+    static sortMenuItems(items: MenuItem[] | undefined, order: SortOrder) {
+        const sort = order === SortOrder.Alphabetically;
+        if (items && sort) {
+            items.sort((a, b) => a.key.localeCompare(b.key));
+
+            for (const item of items) {
+                MenuItem.sortMenuItems(item.items, order);
+            }
+        }
     }
 
     static createFromBinding(item: BindingItem) {

--- a/src/whichKeyCommand.ts
+++ b/src/whichKeyCommand.ts
@@ -35,7 +35,10 @@ export default class WhichKeyCommand {
             MenuItem.overrideMenuItems(this.items, overrides);
         }
 
-        sortMenuItems(this.items);
+        const sortOrder = workspace
+            .getConfiguration(contributePrefix)
+            .get<SortOrder>(ConfigKey.SortOrder) ?? SortOrder.None;
+        MenuItem.sortMenuItems(this.items, sortOrder);
 
         this.onConfigChangeListener = workspace.onDidChangeConfiguration((e) => {
             if (
@@ -63,7 +66,6 @@ export default class WhichKeyCommand {
 
     static show(bindings: BindingItem[], keyWatcher: KeyListener) {
         const items = MenuItem.createMenuItems(bindings);
-        sortMenuItems(items);
         return showMenu(keyWatcher, items, false);
     }
 }
@@ -72,12 +74,6 @@ function setContext(key: string, value: any) {
     return commands.executeCommand("setContext", key, value);
 }
 
-function sortMenuItems(items: MenuItem[] | undefined) {
-    const sortOrder = workspace
-        .getConfiguration(contributePrefix)
-        .get<SortOrder>(ConfigKey.SortOrder) ?? SortOrder.None;
-    MenuItem.sortMenuItems(items, sortOrder);
-}
 
 async function showMenu(keyListener: KeyListener, items: MenuItem[], isTransient: boolean, title?: string) {
     try {


### PR DESCRIPTION
Close #6

Implemented an option to sort which-key menu items. Note that this will only apply to bindings from config.