### PR TITLE
Add some more spacing for icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Icons now have some additional padding
+
 ## [0.9.1] - 2021-06-19
 
 ### Fixed

--- a/src/menu/transientMenuItem.ts
+++ b/src/menu/transientMenuItem.ts
@@ -44,7 +44,7 @@ export class TransientMenuItem implements TransientBindingItem, BaseWhichKeyMenu
     }
 
     get description(): string {
-        const icon = (this.showIcons && this.icon && this.icon.length > 0) ? `$(${this.icon}) ` : "";
+        const icon = (this.showIcons && this.icon && this.icon.length > 0) ? `$(${this.icon})   ` : "";
         return `\t${icon}${this._binding.name}`;
     }
 }

--- a/src/menu/whichKeyMenuItem.ts
+++ b/src/menu/whichKeyMenuItem.ts
@@ -54,7 +54,7 @@ export class WhichKeyMenuItem implements BindingItem, BaseWhichKeyMenuItem {
     }
 
     get description(): string {
-        const icon = (this.showIcons && this.icon && this.icon.length > 0) ? `$(${this.icon}) ` : "";
+        const icon = (this.showIcons && this.icon && this.icon.length > 0) ? `$(${this.icon})   ` : "";
         return `\t${icon}${this._binding.name}`;
     }
 


### PR DESCRIPTION
Without using Customize UI to add some more padding, I felt like the icons were a bit cramped currently:

![image](https://user-images.githubusercontent.com/625793/123281596-1d20a500-d50a-11eb-988a-c4f837137dfa.png)

With this PR:

![image](https://user-images.githubusercontent.com/625793/123281462-00846d00-d50a-11eb-901f-14c5facb9021.png)

I also tried using `\t` instead, but that seems to result in rather small spacing, surprisingly.