### PR TITLE
Test and lint in gh actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+on: [push, pull_request]
+
+name: Build Extension
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout vscode-which-key
+        uses: actions/checkout@v2
+
+      - name: Set up node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: xvfb-run -a npm run test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,21 +2,35 @@ on:
   push:
     tags:
       - v*
+
 name: Deploy Extension
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - name: Checkout vscode-which-key
+        uses: actions/checkout@v2
+
+      - name: Set up node.js
+        uses: actions/setup-node@v2
         with:
           node-version: 12
-      - run: npm ci
+
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: xvfb-run -a npm run test
+
       - name: Publish to Open VSX Registry
         uses: HaaLeo/publish-vscode-extension@v0
         id: publishToOpenVSX
         with:
           pat: ${{ secrets.OVSX_TOKEN }}
+
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v0
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"eslint": "^7.22.0",
 				"glob": "^7.1.6",
 				"mocha": "^8.3.2",
+				"npe": "^1.1.4",
 				"ts-loader": "^8.0.18",
 				"typescript": "^4.2.3",
 				"vscode-test": "^1.5.1",
@@ -2227,6 +2228,12 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/merge": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
+			"integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==",
+			"dev": true
+		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -2441,6 +2448,20 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npe": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/npe/-/npe-1.1.4.tgz",
+			"integrity": "sha512-r8QJhLSwLy9ld72bnH7Dw7mTP0IBa3vPWq9nq84s3OTKGphZ6RoVmwCRDwQPwnxwFloFrHBv/mhQ5YaTPb+RQA==",
+			"dev": true,
+			"dependencies": {
+				"merge": "^2.1.1",
+				"minimist": "^1.2.5",
+				"steeltoe": "^1.0.1"
+			},
+			"bin": {
+				"npe": "index.js"
 			}
 		},
 		"node_modules/npm-run-path": {
@@ -3038,6 +3059,12 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"node_modules/steeltoe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/steeltoe/-/steeltoe-1.0.1.tgz",
+			"integrity": "sha1-W+L0TW3vhWzATZtI9/IxgCI6qMk=",
 			"dev": true
 		},
 		"node_modules/string_decoder": {
@@ -5406,6 +5433,12 @@
 				"yallist": "^4.0.0"
 			}
 		},
+		"merge": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
+			"integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==",
+			"dev": true
+		},
 		"merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5573,6 +5606,17 @@
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 			"dev": true
+		},
+		"npe": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/npe/-/npe-1.1.4.tgz",
+			"integrity": "sha512-r8QJhLSwLy9ld72bnH7Dw7mTP0IBa3vPWq9nq84s3OTKGphZ6RoVmwCRDwQPwnxwFloFrHBv/mhQ5YaTPb+RQA==",
+			"dev": true,
+			"requires": {
+				"merge": "^2.1.1",
+				"minimist": "^1.2.5",
+				"steeltoe": "^1.0.1"
+			}
 		},
 		"npm-run-path": {
 			"version": "4.0.1",
@@ -5999,6 +6043,12 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"steeltoe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/steeltoe/-/steeltoe-1.0.1.tgz",
+			"integrity": "sha1-W+L0TW3vhWzATZtI9/IxgCI6qMk=",
 			"dev": true
 		},
 		"string_decoder": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"onCommand:whichkey.showTransient",
 		"onCommand:whichkey.register"
 	],
-	"main": "./dist/extension.js",
+	"main": "./dist/extension",
 	"contributes": {
 		"keybindings": [
 			{
@@ -1479,10 +1479,10 @@
 	"scripts": {
 		"vscode:prepublish": "webpack --mode production",
 		"compile": "webpack --mode development",
-		"watch": "tsc -watch -p ./",
 		"lint": "eslint src --ext ts",
-		"test-compile": "tsc -p ./",
-		"pretest": "npm run test-compile && npm run lint",
+		"test-compile": "tsc -p .",
+		"pretest": "npm run test-compile && npx npe main ./out/extension",
+		"posttest": "npx npe main ./dist/extension",
 		"test": "node ./out/test/runTest.js"
 	},
 	"devDependencies": {
@@ -1495,6 +1495,7 @@
 		"eslint": "^7.22.0",
 		"glob": "^7.1.6",
 		"mocha": "^8.3.2",
+		"npe": "^1.1.4",
 		"ts-loader": "^8.0.18",
 		"typescript": "^4.2.3",
 		"vscode-test": "^1.5.1",


### PR DESCRIPTION
Test and lint in gh actions

This commits add steps to lint and test extension before we publish on tagging. In addition, another gh action is added to lint and test for all pushes and PRs.

`xvfb-run` is used gh action so the vscode can run in a virtual X server when running in the ubuntu testing environment.

npe is added as dev dependency and being used to change `main` of `package.json` in pre and post test. When building to debug or deploy, webpack is used which outputs a single script file to `dist/extension.js`; When compile for test, typescript compiler (tsc) is used which outputs transpiled js files to `out`. The path to `main` needs to be changed to `out/extension.js` to accommodate the output of tsc, so our extension launched can be activated in the test vscode instance.

See https://github.com/microsoft/vscode/issues/85779