### PR TITLE
add case-based sort order

### DIFF
--- a/package.json
+++ b/package.json
@@ -232,18 +232,21 @@
 						"default": true
 					},
 					"whichkey.sortOrder": {
-						"type": "string",
-						"default": "none",
-						"enum": [
-							"none",
-							"alphabetically",
-							"nonNumberFirst"
-						],
-						"enumDescriptions": [
-							"Menu items are not sorted.",
-							"Menu items are sorted in alphabetical order.",
-							"Menu items are sorted in alphabetical order with non-number first."
-						],
+						"type": "array",
+						"default": [],
+						"items": {
+							"type": "string",
+							"enum": [
+								"alphabetically",
+								"nonNumberFirst",
+								"lowercaseFirst"
+							],
+							"enumDescriptions": [
+								"Menu items are sorted in alphabetical order.",
+								"Menu items are sorted with non-number first.",
+								"Menu items are sorted with lowercase first."
+							]
+						},
 						"markdownDescription": "Controls the sorting order of the which-key menu items."
 					},
 					"whichkey.bindings": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,11 +1,11 @@
 export const extensionId = 'VSpaceCode.whichkey';
 export const contributePrefix = 'whichkey';
 export enum ConfigKey {
-	Delay = "delay",
-	ShowIcons = "showIcons",
-	SortOrder = "sortOrder",
-	Bindings = "bindings",
-	Overrides = "bindingOverrides",
+	Delay = 'delay',
+	ShowIcons = 'showIcons',
+	SortOrder = 'sortOrder',
+	Bindings = 'bindings',
+	Overrides = 'bindingOverrides',
 }
 export enum CommandKey {
 	Show = 'show',
@@ -19,16 +19,17 @@ export enum CommandKey {
 	OpenFile = 'openFile',
 }
 
-export enum SortOrder {
+export enum SortOrderItem {
 	None = 'none',
 	Alphabetically = 'alphabetically',
 	NonNumberFirst = 'nonNumberFirst',
+	LowercaseFirst = 'lowercaseFirst',
 }
 
 export enum ContextKey {
 	Active = 'whichkeyActive',
 	Visible = 'whichkeyVisible',
-	TransientVisible = 'transientVisible'
+	TransientVisible = 'transientVisible',
 }
 
 export const Configs = {


### PR DESCRIPTION
<!-- Please explain the changes you made -->
Added sort based on character case.

This PR changes the `SortOrder` type and has not been tested with non-alphanumeric items.

The following is an example for the new `SortOrder`:
```jsonc
"whichkey.sortOrder": ["alphabetically", "lowercaseFirst", "nonNumberFirst"],
...
```

This change is helpful because it almost replicates the default unsorted configuration and better sorts new items when not specifying a position.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/VSpaceCode/vscode-which-key/blob/master/CONTRIBUTING.md
- you have updated the changelog (if needed):
  https://github.com/VSpaceCode/vscode-which-key/blob/master/CHANGELOG.md
-->

Todo:

Testing and updating changelogs/readmes/documentation.