### PR TITLE
add sort fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix the issue where the new sort options are not effective.
+
 ## [0.11.2] - 2021-12-01
 
 ### Added

--- a/src/whichKeyCommand.ts
+++ b/src/whichKeyCommand.ts
@@ -1,4 +1,5 @@
 import { Disposable, workspace } from "vscode";
+import { getSortComparer } from "./bindingComparer";
 import { CommandRelay } from "./commandRelay";
 import { ActionType, BindingItem, OverrideBindingItem, toCommands, TransientBindingItem } from "./config/bindingItem";
 import { isConditionKeyEqual } from "./config/condition";
@@ -98,29 +99,14 @@ function overrideBindingItems(items: BindingItem[], overrides: OverrideBindingIt
     }
 }
 
-// in place sort
-function sortBindingsItems(items: BindingItem[] | undefined, order: SortOrder): void {
-    if (!items || order === SortOrder.None) {
+function sortBindingsItems(items: BindingItem[] | undefined, comparer: ((a: BindingItem, b: BindingItem) => number) | undefined): void {
+    if (!items || !comparer) {
         return;
     }
 
-    if (order === SortOrder.Alphabetically) {
-        items.sort((a, b) => a.key.localeCompare(b.key));
-    } else if (order === SortOrder.NonNumberFirst) {
-        items.sort((a, b) => {
-            const regex = /^[0-9]/;
-            const aStartsWithNumber = regex.test(a.key);
-            const bStartsWithNumber = regex.test(b.key);
-            if (aStartsWithNumber !== bStartsWithNumber) {
-                // Sort non-number first
-                return aStartsWithNumber ? 1 : -1;
-            } else {
-                return a.key.localeCompare(b.key);
-            }
-        });
-    }
+    items.sort(comparer);
     for (const item of items) {
-        sortBindingsItems(item.bindings, order);
+        sortBindingsItems(item.bindings, comparer);
     }
 }
 
@@ -210,7 +196,8 @@ function getCanonicalConfig(c: WhichKeyConfig): BindingItem[] {
     }
 
     const sortOrder = getConfig<SortOrder>(Configs.SortOrder) ?? SortOrder.None;
-    sortBindingsItems(bindings, sortOrder);
+    const sortComparer = getSortComparer(sortOrder);
+    sortBindingsItems(bindings, sortComparer);
 
     return migrateBindings(bindings);
 }


### PR DESCRIPTION
I somehow missed this when the new sort options were first added.

It seems the commit [https://github.com/VSpaceCode/vscode-which-key/commit/748812859aff3705545debd5e9739ab8a6d3ab5d](https://github.com/VSpaceCode/vscode-which-key/commit/748812859aff3705545debd5e9739ab8a6d3ab5d) reverted an important part of the comparator code.

Without this, the additional sort options don't do anything.