### PR TITLE
conf: add git.update (gu) -> command git.pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Add `<spc> g u` binding `Git Update` to command `git.pull` 
+
 ## [0.11.3] - 2021-12-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -717,6 +717,12 @@
                                         "command": "git.stage"
                                     },
                                     {
+                                        "key": "u",
+                                        "name": "Update",
+                                        "type": "command",
+                                        "command": "git.pull"
+                                    },
+                                    {
                                         "key": "U",
                                         "name": "Unstage",
                                         "type": "command",


### PR DESCRIPTION
# Add default binding for `git pull` operation

## Context

See #66 

## Changes

- Add default binding `<spc> g u` for `Git Update` to command `git.pull` 